### PR TITLE
:sparkles: feat: Implement UserInfo Lookup API, Service, Repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
     id("org.springframework.boot") version "3.1.0"
     id("io.spring.dependency-management") version "1.1.0"
     id("org.asciidoctor.jvm.convert") version "3.3.2"
-    kotlin("jvm") version "1.8.21"
-    kotlin("plugin.spring") version "1.8.21"
-    kotlin("plugin.jpa") version "1.8.21"
+    kotlin("jvm") version "1.9.0"
+    kotlin("plugin.spring") version "1.9.0"
+    kotlin("plugin.jpa") version "1.9.0"
     jacoco
 }
 
@@ -41,7 +41,7 @@ tasks {
     }
 }
 
-val snippetsDir by extra {
+val snippetsDir: File by extra {
     file("build/generated-snippets")
 }
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -10,6 +10,9 @@
 :highlightjs-theme: github
 :highlightjs-languages: java,xml,html,css,js,http
 :docs: src/docs/asciidoc
+:snippets: build/generated-snippets
 
-include::./oauth2/oauth2.adoc[]
-include::./auth/auth.adoc[]
+include::{snippets}/user-find/http-request.adoc[]
+include::{snippets}/user-find/http-response.adoc[]
+include::{snippets}/user-find/path-parameters.adoc[]
+include::{snippets}/user-find/response-fields.adoc[]

--- a/src/main/kotlin/com/practice/kopring/user/application/UserService.kt
+++ b/src/main/kotlin/com/practice/kopring/user/application/UserService.kt
@@ -2,11 +2,13 @@ package com.practice.kopring.user.application
 
 import com.practice.kopring.common.exception.user.NotExistsUserException
 import com.practice.kopring.user.domain.UserEntity
+import com.practice.kopring.user.dto.UserDto
 import com.practice.kopring.user.infrastructure.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(readOnly = true)
 class UserService(
     private val userRepository: UserRepository,
 ) {
@@ -15,4 +17,7 @@ class UserService(
 
     fun findByEmail(email: String): UserEntity =
         this.userRepository.findByEmail(email) ?: throw NotExistsUserException()
+
+    fun findByUserId(userId: String): UserDto.UserResponse =
+        UserDto.UserResponse.of(this.userRepository.findByUserId(userId) ?: throw NotExistsUserException())
 }

--- a/src/main/kotlin/com/practice/kopring/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/practice/kopring/user/dto/UserDto.kt
@@ -1,4 +1,16 @@
 package com.practice.kopring.user.dto
 
+import com.practice.kopring.user.domain.UserEntity
+
 class UserDto {
+    data class UserResponse(
+        val name: String,
+        val email: String,
+        val picture: String
+    ) {
+        companion object {
+            fun of(user: UserEntity): UserResponse =
+                UserResponse(name = user.name, email = user.email, picture = user.picture)
+        }
+    }
 }

--- a/src/main/kotlin/com/practice/kopring/user/infrastructure/UserRepository.kt
+++ b/src/main/kotlin/com/practice/kopring/user/infrastructure/UserRepository.kt
@@ -9,4 +9,5 @@ import java.util.*
 interface UserRepository : JpaRepository<UserEntity, UUID> {
     fun findByEmail(email: String): UserEntity?
     fun existsByEmail(email: String): Boolean
+    fun findByUserId(userId: String): UserEntity?
 }

--- a/src/main/kotlin/com/practice/kopring/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/practice/kopring/user/presentation/UserController.kt
@@ -1,7 +1,16 @@
 package com.practice.kopring.user.presentation
 
+import com.practice.kopring.user.application.UserService
+import com.practice.kopring.user.dto.UserDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
 
 @RestController
-class UserController
+class UserController(private val userService: UserService) {
+    @GetMapping(value = ["/users/{userId}"])
+    fun findByUserId(@PathVariable userId: String): ResponseEntity<UserDto.UserResponse> =
+        ResponseEntity.ok(this.userService.findByUserId(userId))
+}

--- a/src/test/kotlin/com/practice/kopring/RestDocsSupport.kt
+++ b/src/test/kotlin/com/practice/kopring/RestDocsSupport.kt
@@ -1,0 +1,34 @@
+package com.practice.kopring
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+@ExtendWith(RestDocumentationExtension::class)
+abstract class RestDocsSupport {
+    protected val objectMapper: ObjectMapper = ObjectMapper()
+    protected lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setUp(
+        restDocumentationContextProvider: RestDocumentationContextProvider
+    ) {
+        this.mockMvc =
+            MockMvcBuilders
+                .standaloneSetup(initController())
+                .apply<StandaloneMockMvcBuilder>(
+                    MockMvcRestDocumentation.documentationConfiguration(
+                        restDocumentationContextProvider
+                    )
+                )
+                .build()
+    }
+
+    protected abstract fun initController(): Any
+}

--- a/src/test/kotlin/com/practice/kopring/user/presentation/UserControllerTests.kt
+++ b/src/test/kotlin/com/practice/kopring/user/presentation/UserControllerTests.kt
@@ -1,3 +1,0 @@
-package com.practice.kopring.user.presentation
-
-class UserControllerTests


### PR DESCRIPTION
In this commit, the API, Service, and Repository for looking up UserInfo using userId were implemented.

- The GET /users/{userId} API receives a userId and returns the corresponding user information.
- The findByUserId service contains business logic to process the data.
- The repository interacts with the database to fetch the user data.

:bookmark_tabs: test: Add Test Cases for UserInfo Lookup

Added test cases for the new UserInfo Lookup feature. These tests cover both successful scenarios and error scenarios, such as non-existing userId.

:memo: docs: Generate REST Docs for UserInfo Lookup

REST Docs were created to document the UserInfo Lookup API. It describes the GET /users/{userId} request, response, and possible error cases for this API.